### PR TITLE
Corrige caminhos de build, altera encode_base64 para docker-compose.yml e remove inicialização duplicada de app Firebase

### DIFF
--- a/ProductionFiles/VPS/docker-compose.yml
+++ b/ProductionFiles/VPS/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 
   api_scheduler:
     build:
-      context: ./internal-sheduler-server/Internal-server
+      context: ./internal-sheduler-server
       dockerfile: Dockerfile
     container_name: api_scheduler
     working_dir: /app  
@@ -44,7 +44,7 @@ services:
 
   celery_worker_scheduler:
     build:
-      context: ./internal-sheduler-server/Internal-server
+      context: ./internal-sheduler-server
       dockerfile: Dockerfile
     container_name: celery_worker_scheduler
     working_dir: /app  

--- a/ProductionFiles/VPS/encode_base64.py
+++ b/ProductionFiles/VPS/encode_base64.py
@@ -2,6 +2,6 @@ import base64
 import os
 os.chdir(os.path.join(os.path.dirname(__file__)))
 
-with open("Firebasesheduler.json", "rb") as f:
+with open("docker-compose.yml", "rb") as f:
     encoded = base64.b64encode(f.read())
     print(encoded.decode())

--- a/internal-sheduler-server/api.py
+++ b/internal-sheduler-server/api.py
@@ -67,12 +67,6 @@ logger.addHandler(console_handler)
 
 load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), "Keys", "keys.env"))
 
-cred = credentials.Certificate(os.getenv('DATABASEPATH'))
-app1 = initialize_app(cred, {
-    'databaseURL': os.getenv('DATABASEURL')
-}, name="app1")
-
-
 cred = credentials.Certificate(os.getenv('DATABASEPATHSHEDULER'))
 appsheduler = initialize_app(cred, {
     'databaseURL': os.getenv('DATABASEURLSHEDULER')


### PR DESCRIPTION
## Descrição
* Breve resumo das mudanças:
  - Ajuste nos contexts de build para api_scheduler e celery_worker_scheduler apontando para ./internal-sheduler-server em vez de ./internal-sheduler-server/Internal-server.
  - encode_base64.py passa a codificar docker-compose.yml (em vez de Firebasesheduler.json).
  - Remoção da inicialização duplicada de app Firebase (app1) em api.py, mantendo apenas a configuração de app sheduler com DATABASEPATHSHEDULER e DATABASEURLSHEDULER.
* Explicação concisa do propósito geral do PR: alinhar caminhos de build com a estrutura atual do repositório, atualizar a codificação para refletir o arquivo de configuração correto e simplificar a inicialização do Firebase removendo uma configuração redundante que não é mais necessária.

## Mudanças Principais
* Atualização de build e caminhos
  - Arquivos afetados: ProductionFiles/VPS/docker-compose.yml
  - Descrição: Corrige o path de context para api_scheduler e celery_worker_scheduler de ./internal-sheduler-server/Internal-server para ./internal-sheduler-server, assegurando que o Docker build utilize o diretório correto.
* Codificação de conteúdo
  - Arquivos afetados: ProductionFiles/VPS/encode_base64.py
  - Descrição: A função agora codifica/docker-compose.yml em base64 em vez de Firebasesheduler.json, refletindo a nova necessidade de codificar o arquivo de configuração atual.
* Remoção de inicialização Firebase duplicada
  - Arquivos afetados: internal-sheduler-server/api.py
  - Descrição: Remove a inicialização de app1 (credenciais em DATABASEPATH e databaseURL) que era redundante/duplicada, mantendo apenas a configuração do app sheduler com DATABASEPATHSHEDULER e DATABASEURLSHEDULER.

## Por que esta mudança?
* Melhorias de manutenção e clareza: evitar caminhos de build incorretos que poderiam quebrar builds em produção.
* Consistência de configuração: codificar o docker-compose.yml ao invés de um arquivo antigo, tornando o script mais direto e alinhado com a infraestrutura atual.
* Redução de complexidade: remover inicializações redundantes do Firebase para evitar conflitos entre apps e possíveis falhas de inicialização.

## Como testar
* Build e execução
  1. Execute docker-compose up -d na raiz de ProductionFiles/VPS para api_scheduler e celery_worker_scheduler e confirme que os containers iniciam corretamente com os novos contexts.
  2. Verifique logs de criação de containers para confirmar que não há erros de path ou de build.
* Validação do encode_base64
  1. Rode python ProductionFiles/VPS/encode_base64.py e confirme que a saída é o base64 do docker-compose.yml atual.
* Verificação de API
  1. Acesse os endpoints do internal-sheduler-server/api para confirmar que a aplicação carrega com a configuração de app sheduler e que apps adicionais não são inicializados.

## Observações Adicionais (Opcional)
* Sem alterações de dependências externas. Se necessário, valide no ambiente de staging antes do merge.
